### PR TITLE
Persist Money amount field as integer

### DIFF
--- a/config/doctrine/mapping/Money.orm.xml
+++ b/config/doctrine/mapping/Money.orm.xml
@@ -5,7 +5,7 @@
                                       https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <embeddable name="Money\Money">
-        <field name="amount" />
+        <field name="amount" type="integer" />
         <embedded name="currency" class="Money\Currency" use-column-prefix="false" />
     </embeddable>
 </doctrine-mapping>

--- a/tests/DependencyInjection/MoneyExtensionTest.php
+++ b/tests/DependencyInjection/MoneyExtensionTest.php
@@ -149,7 +149,7 @@ class MoneyExtensionTest extends TestCase
         self::assertTrue($metadata->isEmbeddedClass);
         self::assertSame(Money::class, $metadata->getName());
         self::assertSame(['amount', 'currency.code'], $metadata->getFieldNames());
-        self::assertSame('string', $metadata->getTypeOfField('amount'));
+        self::assertSame('integer', $metadata->getTypeOfField('amount'));
         self::assertSame('string', $metadata->getTypeOfField('currency.code'));
         self::assertCount(1, $metadata->embeddedClasses);
         self::assertSame(Currency::class, $metadata->embeddedClasses['currency']['class']);

--- a/tests/Model/MoneyDtoTest.php
+++ b/tests/Model/MoneyDtoTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Yceruto\MoneyBundle\Tests\Model;
 
-use AssertionError;
 use Money\Money;
 use PHPUnit\Framework\TestCase;
 use Throwable;


### PR DESCRIPTION
This will fix comparison behavior in the SQLite query context